### PR TITLE
fix(profile): revert social url to original (#20)

### DIFF
--- a/apps/data/about_data.py
+++ b/apps/data/about_data.py
@@ -43,11 +43,11 @@ class AboutData:
                     "map_url": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d472166.72680191!2d110.27628355896701!3d-7.3869701170751005!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x2e7a73e2eb7ff211%3A0x3027a76e352bc80!2sBoyolali%20Regency%2C%20Central%20Java!5e1!3m2!1sen!2sid!4v1744531766838!5m2!1sen!2sid"
                 },
                 "social_media": {
-                    "github": "https://gh.ridwaanhall.com/",
-                    "linkedin": "https://li.ridwaanhall.com/",
+                    "github": "https://github.com/ridwaanhall",
+                    "linkedin": "https://www.linkedin.com/in/ridwaanhall",
                     "follow_linkedin": "https://linkedin.com/comm/mynetwork/discovery-see-all?usecase=PEOPLE_FOLLOWS&followMember=ridwaanhall",
                     "x": "https://x.com/ridwaanhall",
-                    "instagram": "https://ig.ridwaanhall.com/",
+                    "instagram": "https://www.instagram.com/ridwaanhall",
                     "medium": "https://medium.com/@ridwaanhall",
                     "email": "hi@ridwaanhall.com"
                 },


### PR DESCRIPTION
Restores the original social media URLs for GitHub, LinkedIn, and Instagram in the profile settings. Fixes #20